### PR TITLE
Add include of stdint.h for Linux

### DIFF
--- a/lib/bucket.c
+++ b/lib/bucket.c
@@ -1,6 +1,7 @@
 #include "bucket.h"
 #include <string.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include "packet.h"
 #include "util.h"
   

--- a/lib/crypt.c
+++ b/lib/crypt.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include <stdint.h>
 #include "crypt.h"
 #include "util.h"
 

--- a/lib/hn.c
+++ b/lib/hn.c
@@ -1,6 +1,7 @@
 #include "hn.h"
 #include <string.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include "packet.h"
 #include "crypt.h"
 #include "util.h"

--- a/lib/path.c
+++ b/lib/path.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdint.h>
 #include "js0n.h"
 #include "j0g.h"
 #include "util.h"


### PR DESCRIPTION
Linux compile fails without <stdint.h>
