### PR TITLE
fix milliseconds to timeval conversion for SO_RCVTIMEO

### DIFF
--- a/unix/util.c
+++ b/unix/util.c
@@ -134,8 +134,8 @@ int util_server(int port, int ms)
     perror("bind failed");
     return -1;
   }
-  tv.tv_sec = 0;
-  tv.tv_usec = ms*1000;
+  tv.tv_sec = ms/1000;
+  tv.tv_usec = (ms%1000)*1000;
   if (setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) < 0)
   {
     perror("setsockopt");


### PR DESCRIPTION
On my platform (Mac OS X 10.8.5; Darwin 12.5.0) and possibly others,
SO_RCVTIMEO will reject timevals with a tv_usec value of 1000000 or
greater with an EDOM errno ("Numerical argument out of domain").
This causes the "seed" executable to fail, as it sets a timeout of
1000 milliseconds.

This patch correctly calculates the timeval, and allows the seed to
run.
