### PR TITLE
Documentation calls for roster state "invite"

### DIFF
--- a/util/tft.c
+++ b/util/tft.c
@@ -68,7 +68,7 @@ int main(int argc, char *argv[])
 
   // new chat, must be after-init
   chat = chat_get(s,"tft");
-  chat_add(chat,"*","invited");
+  chat_add(chat,"*","invite");
   p = chat_message(chat);
   packet_set_str(p,"text",nick);
   chat_join(chat,p);


### PR DESCRIPTION
Not "invited" as was here.

https://github.com/telehash/telehash.org/blob/master/ext/chat.md#permissions--roster
