### PR TITLE
replace base32 implementation with a more paranoid modern version

### DIFF
--- a/include/base32.h
+++ b/include/base32.h
@@ -1,13 +1,43 @@
+// Base32 implementation
+//
+// Copyright 2010 Google Inc.
+// Author: Markus Gutschke
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Encode and decode from base32 encoding using the following alphabet:
+//   ABCDEFGHIJKLMNOPQRSTUVWXYZ234567
+// This alphabet is documented in RFC 4668/3548
+//
+// We allow white-space and hyphens, but all other characters are considered
+// invalid.
+//
+// All functions return the number of output bytes or -1 on error. If the
+// output buffer is too small, the result will silently be truncated.
+
+#ifndef _BASE32_H_
+#define _BASE32_H_
+
+#include <stdint.h>
 #include <stddef.h>
 
-#ifndef _b32_h_
-#define _b32_h_
+size_t base32_decode(const char *encoded, size_t length, uint8_t *result, size_t bufSize);
+size_t base32_encode(const uint8_t *data, size_t length, char *result, size_t bufSize);
 
+// number of characters required, including null terminator
 size_t base32_encode_length(size_t rawLength);
-size_t base32_decode_length(size_t base32Length);
-void base32_encode_into(const void *_buffer, size_t bufLen, char *base32Buffer);
-char *base32_encode(const void *buf, size_t len);
-size_t base32_decode_into(const char *base32Buffer, size_t base32BufLen, void *_buffer);
-void *base32_decode(const char *buf, size_t *outlen);
-#endif
 
+// number of bytes, rounded down (truncates extra bits)
+size_t base32_decode_floor(size_t base32Length);
+
+#endif /* _BASE32_H_ */

--- a/src/lib/base32.c
+++ b/src/lib/base32.c
@@ -1,173 +1,107 @@
-/* (PD) 2001 The Bitzi Corporation
- * Please see file COPYING or http://bitzi.com/publicdomain 
- * for more info.
- *
- * $Id: base32.c,v 1.5 2006/03/18 16:28:50 mhe Exp $
- *
- * Modified by Martin Hedenfalk 2005 for use in ShakesPeer.
- */
+// Base32 implementation
+//
+// Copyright 2010 Google Inc.
+// Author: Markus Gutschke
+//
+// Modified 2015 Jeremie Miller
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-#include <assert.h>
-#include <ctype.h>
-#include <stdlib.h>
 #include <string.h>
 
-#define BASE32_LOOKUP_MAX 43
-static char *base32Chars = "abcdefghijklmnopqrstuvwxyz234567";
-static unsigned char base32Lookup[BASE32_LOOKUP_MAX][2] =
-{
-    { '0', 0xFF },
-    { '1', 0xFF },
-    { '2', 0x1A },
-    { '3', 0x1B },
-    { '4', 0x1C },
-    { '5', 0x1D },
-    { '6', 0x1E },
-    { '7', 0x1F },
-    { '8', 0xFF },
-    { '9', 0xFF },
-    { ':', 0xFF },
-    { ';', 0xFF },
-    { '<', 0xFF },
-    { '=', 0xFF },
-    { '>', 0xFF },
-    { '?', 0xFF },
-    { '@', 0xFF },
-    { 'A', 0x00 },
-    { 'B', 0x01 },
-    { 'C', 0x02 },
-    { 'D', 0x03 },
-    { 'E', 0x04 },
-    { 'F', 0x05 },
-    { 'G', 0x06 },
-    { 'H', 0x07 },
-    { 'I', 0x08 },
-    { 'J', 0x09 },
-    { 'K', 0x0A },
-    { 'L', 0x0B },
-    { 'M', 0x0C },
-    { 'N', 0x0D },
-    { 'O', 0x0E },
-    { 'P', 0x0F },
-    { 'Q', 0x10 },
-    { 'R', 0x11 },
-    { 'S', 0x12 },
-    { 'T', 0x13 },
-    { 'U', 0x14 },
-    { 'V', 0x15 },
-    { 'W', 0x16 },
-    { 'X', 0x17 },
-    { 'Y', 0x18 },
-    { 'Z', 0x19 }
-};
+#include "base32.h"
+
+size_t base32_decode(const char *encoded, size_t length, uint8_t *result, size_t bufSize) {
+  int buffer = 0;
+  size_t bitsLeft = 0;
+  size_t count = 0;
+  if(!encoded || !result  || bufSize <= 0) return 0;
+  if(!length) length = strlen(encoded);
+  for (const char *ptr = encoded; (size_t)(ptr-encoded) < length && count < bufSize; ++ptr) {
+    uint8_t ch = (uint8_t)*ptr;
+    if (ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n' || ch == '-') {
+      continue;
+    }
+    buffer <<= 5;
+
+    // Deal with commonly mistyped characters
+    if (ch == '0') {
+      ch = 'O';
+    } else if (ch == '1') {
+      ch = 'L';
+    } else if (ch == '8') {
+      ch = 'B';
+    }
+
+    // Look up one base32 digit
+    if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')) {
+      ch = (ch & 0x1F) - 1;
+    } else if (ch >= '2' && ch <= '7') {
+      ch -= '2' - 26;
+    } else {
+      return 0;
+    }
+
+    buffer |= ch;
+    bitsLeft += 5;
+    if (bitsLeft >= 8) {
+      result[count++] = buffer >> (bitsLeft - 8);
+      bitsLeft -= 8;
+    }
+  }
+  if (count < bufSize) {
+    result[count] = '\000';
+  }
+  return count;
+}
+
+size_t base32_encode(const uint8_t *data, size_t length, char *result, size_t bufSize) {
+  if (!data || !result || !bufSize || !length) return 0;
+  size_t count = 0;
+  if (length > 0) {
+    int buffer = data[0];
+    size_t next = 1;
+    int bitsLeft = 8;
+    while (count < bufSize && (bitsLeft > 0 || next < length)) {
+      if (bitsLeft < 5) {
+        if (next < length) {
+          buffer <<= 8;
+          buffer |= data[next++] & 0xFF;
+          bitsLeft += 8;
+        } else {
+          int pad = 5 - bitsLeft;
+          buffer <<= pad;
+          bitsLeft += pad;
+        }
+      }
+      int index = 0x1F & (buffer >> (bitsLeft - 5));
+      bitsLeft -= 5;
+      result[count++] = "abcdefghijklmnopqrstuvwxyz234567"[index];
+    }
+  }
+  if (count < bufSize) {
+    result[count] = '\000';
+  }
+  return count;
+}
 
 size_t base32_encode_length(size_t rawLength)
 {
-    return ((rawLength * 8) / 5) + ((rawLength % 5) != 0) + 1;
+  return ((rawLength * 8) / 5) + ((rawLength % 5) != 0) + 1;
 }
 
-size_t base32_decode_length(size_t base32Length)
+size_t base32_decode_floor(size_t base32Length)
 {
-    return ((base32Length * 5) / 8);
-}
-
-void base32_encode_into(const void *_buffer, size_t bufLen, char *base32Buffer)
-{
-    size_t i;
-    int index;
-    unsigned char word;
-    const unsigned char *buffer = _buffer;
-
-    for(i = 0, index = 0; i < bufLen;)
-    {
-        /* Is the current word going to span a byte boundary? */
-        if (index > 3)
-        {
-            word = (buffer[i] & (0xFF >> index));
-            index = (index + 5) % 8;
-            word <<= index;
-            if (i < bufLen - 1)
-                word |= buffer[i + 1] >> (8 - index);
-
-            i++;
-        }
-        else
-        {
-            word = (buffer[i] >> (8 - (index + 5))) & 0x1F;
-            index = (index + 5) % 8;
-            if (index == 0)
-                i++;
-        }
-
-        assert(word < 32);
-        *(base32Buffer++) = (char)base32Chars[word];
-    }
-
-    *base32Buffer = 0;
-}
-
-char *base32_encode(const void *buf, size_t len)
-{
-    char *tmp = malloc(base32_encode_length(len));
-    base32_encode_into(buf, len, tmp);
-    return tmp;
-}
-
-size_t base32_decode_into(const char *base32Buffer, size_t base32BufLen, void *_buffer)
-{
-    int lookup;
-    unsigned int i, index, offset;
-    size_t max, bufmax;
-    unsigned char  word;
-    unsigned char *buffer = _buffer;
-
-    max = base32BufLen ? base32BufLen : strlen(base32Buffer);
-    bufmax = base32_decode_length(max);
-    memset(buffer, 0, bufmax);
-    for(i = 0, index = 0, offset = 0; i < max && offset < bufmax; i++)
-    {
-        lookup = toupper(base32Buffer[i]) - '0';
-        /* Check to make sure that the given word falls inside
-           a valid range */
-        if ( lookup < 0 || lookup >= BASE32_LOOKUP_MAX)
-            word = 0xFF;
-        else
-            word = base32Lookup[lookup][1];
-
-        /* If this word is not in the table, ignore it */
-        if (word == 0xFF)
-            continue;
-
-        if (index <= 3)
-        {
-            index = (index + 5) % 8;
-            if (index == 0)
-            {
-                buffer[offset] |= word;
-                offset++;
-            }
-            else
-                buffer[offset] |= word << (8 - index);
-        }
-        else
-        {
-          index = (index + 5) % 8;
-          buffer[offset] |= (word >> index);
-          if(++offset < bufmax) {
-              buffer[offset] |= word << (8 - index);
-          }
-        }
-    }
-    return offset;
-}
-
-void *base32_decode(const char *buf, size_t *outlen)
-{
-    size_t len = strlen(buf);
-    char *tmp = malloc(base32_decode_length(len));
-    size_t x = base32_decode_into(buf, len, tmp);
-    if(outlen)
-        *outlen = x;
-    return tmp;
+  return ((base32Length * 5) / 8);
 }
 

--- a/src/lib/base32.c
+++ b/src/lib/base32.c
@@ -25,9 +25,10 @@ size_t base32_decode(const char *encoded, size_t length, uint8_t *result, size_t
   int buffer = 0;
   size_t bitsLeft = 0;
   size_t count = 0;
+  const char *ptr = encoded;
   if(!encoded || !result  || bufSize <= 0) return 0;
   if(!length) length = strlen(encoded);
-  for (const char *ptr = encoded; (size_t)(ptr-encoded) < length && count < bufSize; ++ptr) {
+  for (; (size_t)(ptr-encoded) < length && count < bufSize; ++ptr) {
     uint8_t ch = (uint8_t)*ptr;
     if (ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n' || ch == '-') {
       continue;

--- a/src/lib/lob.c
+++ b/src/lib/lob.c
@@ -290,7 +290,7 @@ lob_t lob_set_base32(lob_t p, char *key, uint8_t *bin, size_t blen)
   size_t vlen = base32_encode_length(blen)-1; // remove the auto-added \0 space
   if(!(val = malloc(vlen+2))) return LOG("OOM"); // include surrounding quotes
   val[0] = '"';
-  base32_encode_into(bin, blen, val+1);
+  base32_encode(bin, blen, val+1,vlen+1);
   val[vlen+1] = '"';
   lob_set_raw(p,key,0,val,vlen+2);
   return p;
@@ -462,9 +462,9 @@ lob_t lob_get_base32(lob_t p, char *key)
 
   ret = lob_new();
   // make space to decode into the body
-  if(!lob_body(ret,NULL,base32_decode_length(len))) return lob_free(ret);
+  if(!lob_body(ret,NULL,base32_decode_floor(len))) return lob_free(ret);
   // if the decoding wasn't successful, fail
-  if(base32_decode_into(val,len,ret->body) < ret->body_len) return lob_free(ret);
+  if(base32_decode(val,len,ret->body,ret->body_len) < ret->body_len) return lob_free(ret);
   return ret;
 }
 

--- a/src/util/uri.c
+++ b/src/util/uri.c
@@ -158,10 +158,10 @@ lob_t util_uri_paths(lob_t uri)
   {
     value = lob_get_index(query,i+1);
     if(util_cmp(key,"paths") != 0 || !value) continue;
-    len = base32_decode_length(strlen(value));
+    len = base32_decode_floor(strlen(value));
     buf = util_reallocf(buf,len);
     if(!buf) continue;
-    if(base32_decode_into(value,strlen(value),buf) != len) continue;
+    if(base32_decode(value,strlen(value),buf,len) < len) continue;
     paths = lob_link(lob_parse(buf,len), paths);
   }
   free(buf);

--- a/test/lib_base32.c
+++ b/test/lib_base32.c
@@ -4,18 +4,24 @@
 int main(int argc, char **argv)
 {
     const char *str = "foo bar";
-    char *tmp = base32_encode(str, strlen(str));
+    size_t len = base32_encode_length(strlen(str));
+    fail_unless(len = 13);
+    char *tmp = malloc(len);
+    fail_unless(base32_encode((uint8_t*)str, strlen(str), tmp, len) == 12);
+    printf("OUT %s\n",tmp);
     fail_unless(strcmp(tmp,"mzxw6idcmfza") == 0);
 
-    char *data = base32_decode(tmp, NULL);
-    fail_unless(memcmp(data, str, base32_decode_length(strlen(tmp))) == 0);
+    size_t len2 = base32_decode_floor(strlen(tmp));
+    fail_unless(len2 == strlen(str));
+    char *data = malloc(len2);
+    fail_unless(base32_decode(tmp, len, (uint8_t*)data, len2) == len2);
+    fail_unless(memcmp(data, str, base32_decode_floor(strlen(tmp))) == 0);
 
     const char *b = "RF354FEUIXRYFO4O372SXJLKJDIQ2XKIO3XU37OPKEOUEQ7OACWYRFLWDZU5E2QEMESWOS56BIL65HRBFQJHPF4HGWFD6F4E5EJWSA5NZYSHJJP6UZXPUTA5DGOIRIBJILKE65QPP6WBB3I54JRPHUG3XH6NRQTCTLHWAL73NAQ2BCBPKBL3FCZPCAWYNZ7ZN3OHFX2FOZ277IPPLBEZCP6SHDTKJ3CP6SUF2Q6PGZOBFDRFKOX6ERXQADLK6RH4BCOAVRBRQ3S4BTZWLQJI4JKTV7REN4AA22XUJ7AITQFMIMMG4XAA";
-    size_t outlen = 0;
-    void *data2 = base32_decode(b, &outlen);
-    fail_unless(data2);
-    fail_unless(outlen % 24 == 0);
+    size_t outlen = base32_decode_floor(strlen(b));
     fail_unless(outlen == 192);
+    void *data2 = malloc(outlen);
+    fail_unless(base32_decode(b, 0, data2, outlen) == outlen);
 
     return 0;
 }


### PR DESCRIPTION
the previous one had some semantics that lead to really subtle sizing misconceptions, this one is much newer in use in many OTP libs and has strict checks and args.