### PR TITLE
Refactor memcmp to use a constant time algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 test/bin/*
 node_modules/
 telehash.c
+/TAGS

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ HEADERS=$(wildcard include/*.h)
 all: idgen router ping static
 	@echo "TODO\t`git grep TODO | wc -l | tr -d ' '`"
 
-deps: 
+deps:
 	npm install
 
 static: libtelehash
@@ -61,7 +61,7 @@ libtelehash: $(FULL_OBJFILES)
 	rm -f libtelehash.a
 	ar crs libtelehash.a $(FULL_OBJFILES)
 
-.PHONY: arduino test
+.PHONY: arduino test TAGS
 
 arduino: static
 	cp telehash.c arduino/src/telehash/
@@ -72,24 +72,27 @@ arduino: static
 test: $(FULL_OBJFILES) ping
 	cd test; $(MAKE) $(MFLAGS)
 
+TAGS:
+	find . | grep ".*\.\(h\|c\)" | xargs etags -f TAGS
+
 %.o : %.c $(HEADERS)
 	$(CC) $(INCLUDE) $(CFLAGS) -c $< -o $@
 
 idgen: $(IDGEN_OBJFILES)
-	$(CC) $(CFLAGS) -o bin/idgen $(IDGEN_OBJFILES) $(LDFLAGS) 
+	$(CC) $(CFLAGS) -o bin/idgen $(IDGEN_OBJFILES) $(LDFLAGS)
 
 ping: $(PING_OBJFILES)
-	$(CC) $(CFLAGS) -o bin/ping $(PING_OBJFILES) $(LDFLAGS) 
+	$(CC) $(CFLAGS) -o bin/ping $(PING_OBJFILES) $(LDFLAGS)
 
 router: $(ROUTER_OBJFILES)
-	$(CC) $(CFLAGS) -o bin/router $(ROUTER_OBJFILES) $(LDFLAGS) 
+	$(CC) $(CFLAGS) -o bin/router $(ROUTER_OBJFILES) $(LDFLAGS)
 
 #mesh:
 #	$(CC) $(CFLAGS) -o bin/mesh util/mesh.c src/*.c unix/util.c src/ext/*.c $(ARCH)
 
 #port:
 #	$(CC) $(CFLAGS) -o bin/port util/port.c src/*.c unix/util.c src/ext/*.c $(ARCH)
- 
+
 clean:
 	rm -rf bin/*
 	rm -f arduino/src/telehash/*.h

--- a/include/util.h
+++ b/include/util.h
@@ -29,4 +29,7 @@ void *util_reallocf(void *ptr, size_t size);
 uint64_t util_at(void); // only pass at into _since()
 uint32_t util_since(uint64_t at); // get ms since the at
 
+// Use a constant time comparison function to avoid timing attacks
+int util_ct_memcmp(const void* s1, const void* s2, size_t n);
+
 #endif

--- a/src/e3x/cs3a/cs3a.c
+++ b/src/e3x/cs3a/cs3a.c
@@ -65,7 +65,7 @@ e3x_cipher_t cs3a_init(lob_t options)
   ret = malloc(sizeof(struct e3x_cipher_struct));
   if(!ret) return NULL;
   memset(ret,0,sizeof (struct e3x_cipher_struct));
-  
+
   // identifying markers
   ret->id = CS_3a;
   ret->csid = 0x3a;
@@ -145,7 +145,7 @@ local_t local_new(lob_t keys, lob_t secrets)
   secret = lob_get_base32(secrets,"3a");
   if(!secret) return LOG("missing secret");
   if(secret->body_len != crypto_box_SECRETKEYBYTES) return LOG("invalid secret %d != %d",secret->body_len,crypto_box_SECRETKEYBYTES);
-  
+
   if(!(local = malloc(sizeof(struct local_struct)))) return NULL;
   memset(local,0,sizeof (struct local_struct));
 
@@ -216,7 +216,7 @@ remote_t remote_new(lob_t key, uint8_t *token)
 
   if(!key) return LOG("missing key");
   if(key->body_len != crypto_box_PUBLICKEYBYTES) return LOG("invalid key %d != %d",key->body_len,crypto_box_PUBLICKEYBYTES);
-  
+
   if(!(remote = malloc(sizeof(struct remote_struct)))) return NULL;
   memset(remote,0,sizeof (struct remote_struct));
 
@@ -230,7 +230,7 @@ remote_t remote_new(lob_t key, uint8_t *token)
     cipher_hash(remote->ekey,16,hash);
     memcpy(token,hash,16);
   }
-  
+
   return remote;
 }
 
@@ -310,7 +310,7 @@ uint8_t remote_validate(remote_t remote, lob_t args, lob_t sig, uint8_t *data, s
 //    if(sig->body_len != 32 || !args->body_len) return 2;
 //    LOG("[%d] [%.*s]",args->body_len,len,data);
 //    hmac_256(args->body,args->body_len,data,len,hash);
-//    return (memcmp(sig->body,hash,32) == 0) ? 0 : 3;
+//    return (util_ct_memcmp(sig->body,hash,32) == 0) ? 0 : 3;
   }
 
   return 3;
@@ -320,13 +320,13 @@ ephemeral_t ephemeral_new(remote_t remote, lob_t outer)
 {
   uint8_t shared[crypto_box_BEFORENMBYTES+(crypto_box_PUBLICKEYBYTES*2)], hash[32];
   ephemeral_t ephem;
-  
+
   if(!remote) return NULL;
   if(!outer || outer->body_len < crypto_box_PUBLICKEYBYTES) return LOG("invalid outer");
 
   if(!(ephem = malloc(sizeof(struct ephemeral_struct)))) return NULL;
   memset(ephem,0,sizeof (struct ephemeral_struct));
-  
+
   // create and copy in the exchange routing token
   e3x_hash(outer->body,16,hash);
   memcpy(ephem->token,hash,16);
@@ -381,6 +381,6 @@ lob_t ephemeral_decrypt(ephemeral_t ephem, lob_t outer)
     outer->body_len-(16+24),
     outer->body+16,
     ephem->deckey);
-  
+
   return lob_parse(outer->body+16+24, outer->body_len-(16+24+crypto_secretbox_MACBYTES));
 }

--- a/src/e3x/exchange.c
+++ b/src/e3x/exchange.c
@@ -37,7 +37,7 @@ e3x_exchange_t e3x_exchange_new(e3x_self_t self, uint8_t csid, lob_t key)
   x->cs = cs;
   x->self = self;
   memcpy(x->token,token,16);
-  
+
   // determine order, if we sort first, we're even
   for(i = 0; i < key->body_len; i++)
   {
@@ -46,7 +46,7 @@ e3x_exchange_t e3x_exchange_new(e3x_self_t self, uint8_t csid, lob_t key)
     break;
   }
   x->cid = x->order;
-  
+
   return x;
 }
 
@@ -106,7 +106,7 @@ uint32_t e3x_exchange_out(e3x_exchange_t x, uint32_t at)
       if(x->out % 2 == 0) x->out++;
     }
   }
-  
+
   return x->out;
 }
 
@@ -114,10 +114,10 @@ uint32_t e3x_exchange_out(e3x_exchange_t x, uint32_t at)
 uint32_t e3x_exchange_in(e3x_exchange_t x, uint32_t at)
 {
   if(!x) return 0;
-  
+
   // ensure at is newer and valid, or acking our out
   if(at && at > x->in && at >= x->out && (((at % 2)+1) == x->order || at == x->out)) x->in = at;
-  
+
   return x->in;
 }
 
@@ -127,11 +127,11 @@ e3x_exchange_t e3x_exchange_sync(e3x_exchange_t x, lob_t outer)
   ephemeral_t ephem;
   if(!x || !outer) return LOG("bad args");
   if(outer->body_len < 16) return LOG("outer too small");
-  
+
   if(x->in > x->out) x->out = x->in;
 
   // if the incoming ephemeral key is different, create a new ephemeral
-  if(memcmp(outer->body,x->eid,16) != 0)
+  if(util_ct_memcmp(outer->body,x->eid,16) != 0)
   {
     ephem = x->cs->ephemeral_new(x->remote,outer);
     if(!ephem) return LOG("ephemeral creation failed %s",x->cs->err());
@@ -174,7 +174,7 @@ lob_t e3x_exchange_handshake(e3x_exchange_t x, lob_t inner)
 
   // set standard values
   lob_set_uint(inner,"at",x->out);
-  
+
   return e3x_exchange_message(x, inner);
 }
 
@@ -190,7 +190,7 @@ lob_t e3x_exchange_receive(e3x_exchange_t x, lob_t outer)
   return inner;
 }
 
-// comes from channel 
+// comes from channel
 lob_t e3x_exchange_send(e3x_exchange_t x, lob_t inner)
 {
   lob_t outer;
@@ -207,7 +207,7 @@ uint32_t e3x_exchange_cid(e3x_exchange_t x, lob_t incoming)
 {
   uint32_t cid;
   if(!x) return 0;
-  
+
   // in outgoing mode, just return next valid one
   if(!incoming)
   {
@@ -230,4 +230,3 @@ uint8_t *e3x_exchange_token(e3x_exchange_t x)
   if(!x) return NULL;
   return x->token;
 }
-

--- a/src/lib/lob.c
+++ b/src/lib/lob.c
@@ -319,8 +319,8 @@ char *unescape(lob_t p, char *start, size_t len)
   // make a copy if we haven't yet
   if(!p->cache) lob_json(p);
   if(!p->cache) return NULL;
-  
-  // switch pointer to the json copy 
+
+  // switch pointer to the json copy
   start = p->cache + (start - (char*)p->head);
 
   // terminate it
@@ -393,7 +393,7 @@ unsigned int lob_get_uint(lob_t p, char *key)
   return (unsigned int)strtoul(val,NULL,10);
 }
 
-// returns ["0","1","2"] 
+// returns ["0","1","2"]
 char *lob_get_index(lob_t p, uint32_t i)
 {
   char *val;
@@ -537,7 +537,7 @@ int lob_cmp(lob_t a, lob_t b)
     i++;
   }
 
-  return memcmp(a->body,b->body,a->body_len);
+  return util_ct_memcmp(a->body,b->body,a->body_len);
 }
 
 lob_t lob_set_json(lob_t p, lob_t json)

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -69,7 +69,7 @@ int util_cmp(char *a, char *b)
   if(!a || !b) return -1;
   if(a == b) return 0;
   if(strlen(a) != strlen(b)) return -1;
-  return memcmp(a,b,strlen(a));
+  return util_ct_memcmp(a,b,strlen(a));
 }
 
 // default alpha sort
@@ -151,11 +151,11 @@ uint64_t util_at(void)
 {
   uint64_t at;
   uint32_t *half = (uint32_t*)(&at);
-  
+
   // store both current seconds and ms since then in one value
   half[0] = util_sys_seconds();
   half[1] = (uint32_t)util_sys_ms(half[0]);
-  
+
   return at;
 }
 
@@ -163,4 +163,23 @@ uint32_t util_since(uint64_t at)
 {
   uint32_t *half = (uint32_t*)(&at);
   return ((uint32_t)util_sys_ms(half[0]) - half[1]);
+}
+
+int util_ct_memcmp(const void* s1, const void* s2, size_t n)
+{
+    const unsigned char *p1 = s1, *p2 = s2;
+    int x = 0;
+
+    while (n--)
+    {
+        x |= (*p1 ^ *p2);
+        p1++;
+        p2++;
+    }
+
+    /* Don't leak any info besides failure */
+    if (x)
+        x = 1;
+
+    return x;
 }

--- a/test/lib_util.c
+++ b/test/lib_util.c
@@ -15,6 +15,25 @@ int main(int argc, char **argv)
   sleep(1);
   fail_unless(util_since(at));
 
+  // test the constant time memcmp
+  uint8_t buf1[] = {0x03};
+  uint8_t buf2[] = {0x01, 0x02};
+  uint8_t buf3[] = {0x01, 0x02};
+  uint8_t buf4[] = {0x01, 0x02, 0x03};
+  uint8_t buf5[] = {0x01, 0x04, 0x03};
+  uint8_t buf6[] = {0x02, 0x02, 0x03};
+  uint8_t buf7[] = {0x01, 0x02, 0x04};
+
+  fail_unless(util_ct_memcmp(buf2, buf2, sizeof(buf2)) == 0);
+  fail_unless(util_ct_memcmp(buf2, buf3, sizeof(buf2)) == 0);
+  fail_unless(util_ct_memcmp(buf3, buf4, sizeof(buf3)) == 0);
+  fail_unless(util_ct_memcmp(buf3, buf4, sizeof(buf3)) == 0);
+
+  // Negative test cases
+  fail_unless(util_ct_memcmp(buf1, buf2, sizeof(buf1)) != 0);
+  fail_unless(util_ct_memcmp(buf4, buf5, sizeof(buf5)) != 0);
+  fail_unless(util_ct_memcmp(buf4, buf6, sizeof(buf5)) != 0);
+  fail_unless(util_ct_memcmp(buf4, buf7, sizeof(buf5)) != 0);
+
   return 0;
 }
-


### PR DESCRIPTION
The stdlib memcmp is vulnerable to timing attacks because it fails at first difference. This PR defines util_ct_memcmp which is the same signature as memcmp but will not leak timing.

It also adds a make TAGS to be more friendly to emacs users.