### PR TITLE
Fixes to util_uri_parse for path and hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,3 @@
 test/bin/*
 node_modules/
 telehash.c
-.project
-.cproject
-.settings/*
-.travis.yml
-

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@
 test/bin/*
 node_modules/
 telehash.c
+.project
+.cproject
+.settings/*
+.travis.yml
+

--- a/src/util/uri.c
+++ b/src/util/uri.c
@@ -54,18 +54,19 @@ lob_t util_uri_parse(char *encoded)
   // optional path
   if((at = strchr(encoded,'/')))
   {
-    if((at = strchr(at+1,'?')) || (at = strchr(at+1,'#')))
+    encoded = at;
+    at = strchr(encoded+1,'?');
+    if(at || (at = strchr(encoded+1,'#')))
     {
       lob_set_len(uri, "path", 0, encoded, (size_t)(at - encoded));
     }else{
       lob_set_len(uri, "path", 0, encoded, strlen(encoded));
     }
-  }
 
   // optional hash at the end
   if((at = strchr(encoded,'#')))
   {
-    lob_set_len(uri, "path", 0, at+1, strlen(at+1));
+    lob_set_len(uri, "hash", 0, at+1, strlen(at+1));
   }
 
   // optional query string

--- a/src/util/uri.c
+++ b/src/util/uri.c
@@ -54,18 +54,19 @@ lob_t util_uri_parse(char *encoded)
   // optional path
   if((at = strchr(encoded,'/')))
   {
-    if((at = strchr(at+1,'?')) || (at = strchr(at+1,'#')))
+    encoded = at;
+    at = strchr(encoded+1,'?');
+    if(at || (at = strchr(encoded+1,'#')))
     {
       lob_set_len(uri, "path", 0, encoded, (size_t)(at - encoded));
     }else{
       lob_set_len(uri, "path", 0, encoded, strlen(encoded));
     }
   }
-
   // optional hash at the end
   if((at = strchr(encoded,'#')))
   {
-    lob_set_len(uri, "path", 0, at+1, strlen(at+1));
+    lob_set_len(uri, "hash", 0, at+1, strlen(at+1));
   }
 
   // optional query string

--- a/src/util/uri.c
+++ b/src/util/uri.c
@@ -54,19 +54,18 @@ lob_t util_uri_parse(char *encoded)
   // optional path
   if((at = strchr(encoded,'/')))
   {
-    encoded = at;
-    at = strchr(encoded+1,'?');
-    if(at || (at = strchr(encoded+1,'#')))
+    if((at = strchr(at+1,'?')) || (at = strchr(at+1,'#')))
     {
       lob_set_len(uri, "path", 0, encoded, (size_t)(at - encoded));
     }else{
       lob_set_len(uri, "path", 0, encoded, strlen(encoded));
     }
+  }
 
   // optional hash at the end
   if((at = strchr(encoded,'#')))
   {
-    lob_set_len(uri, "hash", 0, at+1, strlen(at+1));
+    lob_set_len(uri, "path", 0, at+1, strlen(at+1));
   }
 
   // optional query string


### PR DESCRIPTION
Variable 'encoded' wasn't being reset inside the optional path code segment at line 55
lob_set_len on line 68 should be for "hash" instead of "path"

line 57:  if((at = strchr(at+1,'?')) || (at = strchr(at+1,'#')))
Segment fault in strchr(at+1,'#') if first test set 'at' to NULL

  