### PR TITLE
making all tmesh time relative and 32bit microseconds

### DIFF
--- a/include/tmesh.h
+++ b/include/tmesh.h
@@ -121,8 +121,11 @@ mote_t mote_free(mote_t m);
 // resets secret/nonce and to ping mode
 mote_t mote_reset(mote_t m);
 
+// advance window, set relative time
+mote_t mote_bttf(mote_t m, uint32_t us);
+
 // next knock init
-mote_t mote_knock(mote_t m, knock_t k, uint32_t us);
+mote_t mote_knock(mote_t m, knock_t k);
 
 // initiates handshake over this synchronized mote
 mote_t mote_synced(mote_t m);

--- a/include/tmesh.h
+++ b/include/tmesh.h
@@ -78,7 +78,8 @@ tmesh_t tmesh_loop(tmesh_t tm);
 struct knock_struct
 {
   mote_t mote;
-  uint32_t start, stop, actual; // microsecond exact start/stop time
+  uint32_t start, stop;
+  int16_t actual; // microsecond drift from start
   uint8_t frame[64];
   uint8_t chan; // current channel (< med->chans)
   uint8_t tx:1; // tells radio to tx or rx

--- a/include/tmesh.h
+++ b/include/tmesh.h
@@ -104,7 +104,7 @@ struct mote_struct
   uint8_t nonce[8];
   uint8_t nwait[8]; // future nonce
   uint8_t chan[2];
-  uint32_t next; // microseconds until next knock
+  uint32_t at; // microseconds until next knock
   util_chunks_t chunks; // actual chunk encoding for r/w frame buffers
   uint16_t sent, received;
   uint8_t z;
@@ -121,7 +121,7 @@ mote_t mote_free(mote_t m);
 // resets secret/nonce and to ping mode
 mote_t mote_reset(mote_t m);
 
-// advance window, set relative time
+// advance window by relative time
 mote_t mote_bttf(mote_t m, uint32_t us);
 
 // next knock init
@@ -131,7 +131,7 @@ mote_t mote_knock(mote_t m, knock_t k);
 mote_t mote_synced(mote_t m);
 
 // find the first nonce that occurs after this future time of this type
-mote_t mote_seek(mote_t m, uint32_t after, uint8_t tx, uint8_t *nonce);
+mote_t mote_wait(mote_t m, uint32_t after, uint8_t tx, uint8_t *set);
 
 // for tmesh sorting
 knock_t knock_sooner(knock_t a, knock_t b);

--- a/include/tmesh.h
+++ b/include/tmesh.h
@@ -78,19 +78,21 @@ tmesh_t tmesh_loop(tmesh_t tm);
 struct knock_struct
 {
   mote_t mote;
-  uint64_t start, stop, actual; // microsecond exact start/stop time
+  uint32_t start, stop, actual; // microsecond exact start/stop time
   uint8_t frame[64];
   uint8_t chan; // current channel (< med->chans)
   uint8_t tx:1; // tells radio to tx or rx
 };
 
-// fills in next knock based on from and only for this device
-tmesh_t tmesh_knock(tmesh_t tm, knock_t k, uint64_t from, radio_t device);
-tmesh_t tmesh_knocked(tmesh_t tm, knock_t k); // process done knock
+// advance all windows forward this many microseconds, all knocks are relative to this call
+tmesh_t tmesh_bttf(tmesh_t tm, uint32_t us);
 
+// fills in next knock for this device only
+tmesh_t tmesh_knock(tmesh_t tm, knock_t k, radio_t device);
 
-// 2^18
-#define EPOCH_WINDOW (uint64_t)262144
+// process done knock
+tmesh_t tmesh_knocked(tmesh_t tm, knock_t k);
+
 
 // mote state tracking
 struct mote_struct
@@ -102,8 +104,7 @@ struct mote_struct
   uint8_t nonce[8];
   uint8_t nwait[8]; // future nonce
   uint8_t chan[2];
-  uint64_t at; // microsecond of last knock
-  uint64_t tmp; // TODO remove, for debugging only
+  uint32_t next; // microseconds until next knock
   util_chunks_t chunks; // actual chunk encoding for r/w frame buffers
   uint16_t sent, received;
   uint8_t z;
@@ -121,13 +122,13 @@ mote_t mote_free(mote_t m);
 mote_t mote_reset(mote_t m);
 
 // next knock init
-mote_t mote_knock(mote_t m, knock_t k, uint64_t from);
+mote_t mote_knock(mote_t m, knock_t k, uint32_t us);
 
 // initiates handshake over this synchronized mote
 mote_t mote_synced(mote_t m);
 
-// find the first nonce that occurs after this future time of this type, return that time
-uint64_t mote_seek(mote_t m, uint32_t after, uint8_t tx, uint8_t *nonce);
+// find the first nonce that occurs after this future time of this type
+mote_t mote_seek(mote_t m, uint32_t after, uint8_t tx, uint8_t *nonce);
 
 // for tmesh sorting
 knock_t knock_sooner(knock_t a, knock_t b);

--- a/src/tmesh/tmesh.c
+++ b/src/tmesh/tmesh.c
@@ -617,7 +617,7 @@ mote_t mote_wait(mote_t m, uint32_t after, uint8_t tx, uint8_t *set)
   memcpy(m->nwait,nonce,8);
   m->waiting = 1;
   
-  if(set && memcmp(set,nonce,8) != 0) LOG("warning, set wait nonce was not found in window sequence");
+  if(set && memcmp(set,nonce,8) != 0) return LOG("warning, set wait nonce was not found in window sequence");
 
   return m;
 }

--- a/src/tmesh/tmesh.c
+++ b/src/tmesh/tmesh.c
@@ -634,7 +634,11 @@ mote_t mote_bttf(mote_t m, uint32_t us)
     chacha20(m->secret,m->nonce,m->nonce,8);
     m->at = mote_next(m->nonce,m->z);
     // clear wait if matched
-    if(m->waiting && memcmp(m->nwait,m->nonce,8) == 0) m->waiting = 0;
+    if(m->waiting && memcmp(m->nwait,m->nonce,8) == 0)
+    {
+      LOG("clearing mote wait");
+      m->waiting = 0;
+    }
   }
   
   // move relative forward
@@ -647,7 +651,7 @@ mote_t mote_bttf(mote_t m, uint32_t us)
 mote_t mote_knock(mote_t m, knock_t k)
 {
   if(!m || !k) return LOG("bad args");
-  if(!m->at) return NULL;//LOG("paused mote %s",m->link?m->link->id->hashname:"public beacon");
+  if(m->waiting) return LOG("mote waiting: %s",m->link?m->link->id->hashname:"public beacon");
 
   k->mote = m;
   k->start = k->stop = 0;

--- a/src/tmesh/tmesh.c
+++ b/src/tmesh/tmesh.c
@@ -399,7 +399,7 @@ tmesh_t tmesh_knocked(tmesh_t tm, knock_t k)
   if(k->tx)
   {
     // use actual tx time to auto-correct for drift
-    k->mote->at = k->actual;
+    k->mote->at += k->actual;
 
     k->mote->sent++;
     LOG("tx done, total %d",k->mote->sent);
@@ -427,8 +427,7 @@ tmesh_t tmesh_knocked(tmesh_t tm, knock_t k)
     uint8_t pong = (memcmp(k->mote->nonce,k->frame,8) == 0) ? 1 : 0;
 
     // always sync wait to the bundled nonce for the next pong
-    if(k->mote->at != k->actual) LOG("adjusting time sync by %ld",k->actual-k->mote->at);
-    k->mote->at = k->actual;
+    k->mote->at += k->actual;
     memcpy(k->mote->nonce,k->frame,8);
     mote_wait(k->mote,k->mote->com->medium->min+k->mote->com->medium->max,1,k->frame+8);
     k->mote->pong = 1;
@@ -478,7 +477,7 @@ tmesh_t tmesh_knocked(tmesh_t tm, knock_t k)
   // TODO check and validate frame[0] now
 
   // self-correcting sync based on exact rx time
-  k->mote->at = k->actual;
+  k->mote->at += k->actual;
 
   // received stats only after minimal validation
   k->mote->received++;

--- a/src/tmesh/tmesh.c
+++ b/src/tmesh/tmesh.c
@@ -297,14 +297,14 @@ tmesh_t tmesh_bttf(tmesh_t tm, uint32_t us)
 {
   cmnty_t com;
   mote_t mote;
-  if(!tm || !k) return LOG("bad args");
+  if(!tm || !us) return LOG("bad args");
 
   for(com=tm->coms;com;com=com->next)
   {
-    // check every mote
+    // inform every
     for(mote=com->motes;mote;mote=mote->next)
     {
-//      mote_knock(mote,&ktmp,from);
+      mote_bttf(mote,us);
     }
   }
   
@@ -328,6 +328,8 @@ tmesh_t tmesh_knock(tmesh_t tm, knock_t k, radio_t device)
     for(mote=com->motes;mote;mote=mote->next)
     {
       // TODO, optimize skipping tx knocks if nothing to send
+      mote_knock(mote,&ktmp);
+
       // use the new one if preferred
       if(!k->mote || tm->sort(k,&ktmp) != k)
       {
@@ -340,7 +342,6 @@ tmesh_t tmesh_knock(tmesh_t tm, knock_t k, radio_t device)
   if(!k->mote) return NULL;
   
   LOG("mote %s nonce %s",k->mote->public?"public beacon":k->mote->link->id->hashname,util_hex(k->mote->nonce,8,NULL));
-  if(k->mote->tmp) LOG("knock start offset from first sync %lu",k->start - k->mote->tmp);
 
   // receive is on knocked
   if(!k->tx) return tm;
@@ -350,9 +351,8 @@ tmesh_t tmesh_knock(tmesh_t tm, knock_t k, radio_t device)
   {
     // copy in ping nonce
     memcpy(k->frame,k->mote->nonce,8);
-    // bundle a future rx nonce that we'll wait for next
-    mote_seek(k->mote,k->mote->com->medium->min+k->mote->com->medium->max,0,k->mote->nwait);
-    k->mote->waiting = 1;
+    // wait for the next future rx nonce
+    mote_wait(k->mote,k->mote->com->medium->min+k->mote->com->medium->max,0,NULL);
     memcpy(k->frame+8,k->mote->nwait,8);
     // copy in hashname
     memcpy(k->frame+8+8,tm->mesh->id->bin,32);
@@ -430,8 +430,7 @@ tmesh_t tmesh_knocked(tmesh_t tm, knock_t k)
     if(k->mote->at != k->actual) LOG("adjusting time sync by %ld",k->actual-k->mote->at);
     k->mote->at = k->actual;
     memcpy(k->mote->nonce,k->frame,8);
-    memcpy(k->mote->nwait,k->frame+8,8);
-    k->mote->waiting = 1;
+    mote_wait(k->mote,k->mote->com->medium->min+k->mote->com->medium->max,1,k->frame+8);
     k->mote->pong = 1;
     LOG("waiting for nonce %s",util_hex(k->mote->nwait,8,NULL));
 
@@ -591,40 +590,56 @@ uint32_t mote_next(uint8_t *nonce, uint8_t z)
   return next;
 }
 
-// find the first nonce that occurs after this future time of this type
-uint64_t mote_seek(mote_t m, uint32_t after, uint8_t tx, uint8_t *nonce)
+// set mote to wait for the first nonce that occurs after this future time of this type, match set nonce if given
+mote_t mote_wait(mote_t m, uint32_t after, uint8_t tx, uint8_t *set)
 {
-  if(!m || !nonce || !after) return 0;
+  uint8_t nonce[8];
+  if(!m || !after) return LOG("bad args");
   
   memcpy(nonce,m->nonce,8);
   uint32_t at = mote_next(nonce,m->z);
   uint8_t atx = ((nonce[7] & 0b00000001) == m->order) ? 0 : 1;
   while(at < after || atx != tx)
   {
+    // once after is passed, keep at zero
+    if(at > after) after = 0;
+    else after -= at;
+
+    // step forward
     chacha20(m->secret,nonce,nonce,8);
-    at += mote_next(nonce,m->z);
+    at = mote_next(nonce,m->z);
     atx = ((nonce[7] & 0b00000001) == m->order) ? 0 : 1;
+    
+    // see if any given nonce matches to stop at early
+    if(set && atx == tx && memcmp(set,nonce,8) == 0) break;
   }
   
-//  LOG("seeking tx %d after %u got %s at %lu",tx,after,util_hex(nonce,8,NULL),at);
-  return at;
+  memcpy(m->nwait,nonce,8);
+  m->waiting = 1;
+  
+  if(set && memcmp(set,nonce,8) != 0) LOG("warning, set wait nonce was not found in window sequence");
+
+  return m;
 }
 
-// advance window, set relative time
+// advance window by relative time
 mote_t mote_bttf(mote_t m, uint32_t us)
 {
   if(!m || !us) return LOG("bad args");
 
-  while(us > m->next)
+  while(us > m->at)
   {
+    // trim relative
+    us -= m->at;
     // rotate nonce by ciphering it
     chacha20(m->secret,m->nonce,m->nonce,8);
-    m->at += mote_next(m->nonce,m->z);
+    m->at = mote_next(m->nonce,m->z);
     // clear wait if matched
     if(m->waiting && memcmp(m->nwait,m->nonce,8) == 0) m->waiting = 0;
-    // waiting failsafe
-    if(m->at > (from + 1000*1000*100)) return LOG("waiting nonce not found by %d %d",(m->at/1000),(from/1000));
   }
+  
+  // move relative forward
+  m->at -= us;
 
   return m;
 }
@@ -648,12 +663,16 @@ mote_t mote_knock(mote_t m, knock_t k)
   // least significant nonce bit sets direction
   k->tx = ((m->nonce[7] & 0b00000001) == m->order) ? 0 : 1;
 
+  // set relative start/stop times
   k->start = m->at;
-  k->stop = k->start + (uint64_t)((k->tx) ? m->com->medium->max : m->com->medium->min);
+  k->stop = k->start + ((k->tx) ? m->com->medium->max : m->com->medium->min);
 
   // when receiving a ping, use wide window to catch more
   if(m->ping) k->stop = k->start + m->com->medium->max;
-  
+
+  // very remote case of overlow (70min minus max micros), just sets to max avail, slight inefficiency
+  if(k->stop < k->start) k->stop = 0xffffffff;
+
   // derive current channel
   k->chan = m->chan[1] % m->com->medium->chans;
 
@@ -686,9 +705,6 @@ mote_t mote_synced(mote_t m)
     return m;
   }
   
-  // TODO remove, for debug only
-  m->tmp = m->at; // save first sync for differential logging
-
   // TODO, set up first sync timeout to reset!
   m->ping = 0;
   util_chunks_free(m->chunks);

--- a/test/tmesh_core.c
+++ b/test/tmesh_core.c
@@ -67,10 +67,10 @@ int main(int argc, char **argv)
   knock_t knock = malloc(sizeof(struct knock_struct));
   fail_unless(mote_bttf(m,4200000));
   LOG("next is %lld",m->at);
-  fail_unless(m->at == 8599862);
+  fail_unless(m->at == 4399862);
   fail_unless(mote_knock(m,knock));
   fail_unless(knock->tx);
-  fail_unless(mote_bttf(m,8599862+1));
+  fail_unless(mote_bttf(m,4399862+1));
   fail_unless(mote_knock(m,knock));
   fail_unless(!knock->tx);
   LOG("next is %lld",knock->start);

--- a/test/tmesh_core.c
+++ b/test/tmesh_core.c
@@ -74,7 +74,7 @@ int main(int argc, char **argv)
   fail_unless(mote_knock(m,knock));
   fail_unless(!knock->tx);
   LOG("next is %lld",knock->start);
-  fail_unless(knock->start == 20170206);
+  fail_unless(knock->start == 11570343);
 
   mote_reset(m);
   memset(m->nonce,2,8); // nonce is random, force stable for fixture testing
@@ -84,28 +84,26 @@ int main(int argc, char **argv)
   fail_unless(knock->mote == m);
   LOG("tx %d start %lld stop %lld chan %d at %lld",knock->tx,knock->start,knock->stop,knock->chan,m->at);
   fail_unless(knock->tx);
-  fail_unless(knock->start == 2779758);
-  fail_unless(knock->stop == 2779758+1000);
+  fail_unless(knock->start == 2779756);
+  fail_unless(knock->stop == 2779756+1000);
   fail_unless(knock->chan == 30);
-  fail_unless(m->at == 2779758);
-  knock->actual = knock->start;
+  fail_unless(m->at == 2779756);
+  knock->actual = 1;
   fail_unless(tmesh_knocked(netA,knock));
-  fail_unless(m->at == knock->start);
   
   uint8_t nonce[8];
   fail_unless(mote_wait(m,4242424242,1,NULL));
   LOG("seek %s",util_hex(m->nwait,8,hex));
   fail_unless(util_cmp(hex,"15b28afc066a9f8f") == 0);
   memcpy(nonce,m->nwait,8);
-  fail_unless(mote_wait(m,42424242,0,nonce));
+  fail_unless(mote_wait(m,4242424242,1,nonce));
   LOG("seek %s",util_hex(nonce,8,hex));
-  fail_unless(util_cmp(hex,"218e5955e2326f46") == 0);
-  struct knock_struct ktmp;
-  fail_unless(mote_knock(m,&ktmp));
+  fail_unless(util_cmp(hex,"15b28afc066a9f8f") == 0);
+  fail_unless(mote_bttf(m,4242424243));
   fail_unless(m->waiting == 0);
   fail_unless(memcmp(m->nonce,nonce,8) == 0);
   LOG("at is %lu",m->at);
-  fail_unless(m->at >= 46592337);
+  fail_unless(m->at >= 16019871);
 
   // public ping now
   m->at = 424294967; // force way future
@@ -115,8 +113,8 @@ int main(int argc, char **argv)
   fail_unless(knock->mote == m);
   LOG("tx %d start %lld stop %lld chan %d",knock->tx,knock->start,knock->stop,knock->chan);
   fail_unless(knock->tx);
-  fail_unless(knock->start == 5223482);
-  fail_unless(knock->stop == 5223482+1000);
+  fail_unless(knock->start == 5223477);
+  fail_unless(knock->stop == 5223477+1000);
   fail_unless(knock->chan == 14);
   // pretend rx failed
   fail_unless(tmesh_knocked(netA,knock));
@@ -128,16 +126,15 @@ int main(int argc, char **argv)
   fail_unless(knock->mote == m);
   LOG("tx %d start %lld stop %lld chan %d",knock->tx,knock->start,knock->stop,knock->chan);
   fail_unless(knock->tx);
-  fail_unless(knock->start == 439009220);
+  fail_unless(knock->start == 1530280);
   fail_unless(knock->chan == 14);
   // frame would be random ciphered, but we fixed it to test
   LOG("frame %s",util_hex(knock->frame,32+8,hex)); // just the stable part
   fail_unless(util_cmp(hex,"0731ffea6a27124b0731ffea6a27124b6ea8a74bc285295d4f4d667c4f30a5266b66abc8e1a45e9b") == 0);
   // let's preted it's an rx now
   knock->tx = 0;
-  knock->actual = knock->start; // fake rx good
+  knock->actual = 1; // fake rx good
   fail_unless(tmesh_knocked(netA,knock));
-  fail_unless(m->at == knock->actual);
   // frame is deciphered
   LOG("frame %s",util_hex(knock->frame,32+8,hex)); // just the stable part
   fail_unless(memcmp(knock->frame,m->nonce,8) == 0);
@@ -223,17 +220,17 @@ int main(int argc, char **argv)
   fail_unless(tmesh_knock(netA,knAB,NULL));
   fail_unless(knAB->mote == mAB);
   LOG("tx is %d chan %d at %lu nonce %s",knAB->tx,knAB->chan,knAB->start,util_hex(mAB->nonce,8,NULL));
-  fail_unless(knAB->tx == 1);
+  fail_unless(knAB->tx == 0);
   fail_unless(tmesh_bttf(netB,1));
   fail_unless(tmesh_knock(netB,knBA,NULL));
   fail_unless(knBA->mote == mBA);
   LOG("tx is %d chan %d at %lu nonce %s",knBA->tx,knBA->chan,knAB->start,util_hex(mBA->nonce,8,NULL));
-  fail_unless(knBA->tx == 0);
+  fail_unless(knBA->tx == 1);
   
   // dance
   memcpy(knBA->frame,knAB->frame,64);
-  knAB->actual = knAB->start;
-  knBA->actual = knAB->start;
+  knAB->actual = 1;
+  knBA->actual = 1;
   fail_unless(tmesh_knocked(netB,knBA)); // the rx
   // in sync!
   fail_unless(!mBA->pong);

--- a/test/tmesh_core.c
+++ b/test/tmesh_core.c
@@ -184,48 +184,44 @@ int main(int argc, char **argv)
   
   knock_t knAB;
   knAB = malloc(sizeof(struct knock_struct));
-  mAB->at = 1;
   memset(mAB->nonce,12,8);
-  fail_unless(tmesh_bttf(netA,3));
+  fail_unless(tmesh_bttf(netA,1));
   fail_unless(tmesh_knock(netA,knAB,NULL));
   fail_unless(knAB->mote == mAB);
-  LOG("tx is %d chan %d at %lu nonce %s",knAB->tx,knAB->chan,knAB->start,util_hex(mAB->nonce,8,NULL));
+  LOG("AB tx is %d chan %d at %lu nonce %s",knAB->tx,knAB->chan,knAB->start,util_hex(mAB->nonce,8,NULL));
   fail_unless(knAB->chan == 35);
   fail_unless(knAB->tx == 0);
 
   knock_t knBA;
   knBA = malloc(sizeof(struct knock_struct));
-  mBA->at = 1;
   memset(mBA->nonce,0,8);
-  fail_unless(tmesh_bttf(netB,3));
+  fail_unless(tmesh_bttf(netB,1));
   fail_unless(tmesh_knock(netB,knBA,NULL));
   fail_unless(knBA->mote == mBA);
-  LOG("tx is %d chan %d at %lu",knBA->tx,knBA->chan,knAB->start);
+  LOG("BA tx is %d chan %d at %lu",knBA->tx,knBA->chan,knAB->start);
   fail_unless(knBA->chan == 35);
   fail_unless(knBA->tx == 1);
 
   // fake reception, with fake cake
   memcpy(knAB->frame,knBA->frame,64);
-  knAB->actual = knBA->start;
-  knBA->actual = knBA->start;
+  knAB->actual = 1;
+  knBA->actual = 1;
   fail_unless(tmesh_knocked(netA,knAB)); // the rx
   fail_unless(mAB->pong);
   fail_unless(mAB->waiting);
   fail_unless(memcmp(mAB->nonce,mBA->nonce,8) == 0);
   fail_unless(memcmp(mAB->nwait,mBA->nwait,8) == 0);
   fail_unless(tmesh_knocked(netB,knBA)); // the tx
-  
+
   // back to the future
-  fail_unless(tmesh_bttf(netA,1));
-  fail_unless(tmesh_knock(netA,knAB,NULL));
+  while(!tmesh_knock(netA,knAB,NULL)) fail_unless(tmesh_bttf(netA,mAB->at+1));
   fail_unless(knAB->mote == mAB);
-  LOG("tx is %d chan %d at %lu nonce %s",knAB->tx,knAB->chan,knAB->start,util_hex(mAB->nonce,8,NULL));
-  fail_unless(knAB->tx == 0);
-  fail_unless(tmesh_bttf(netB,1));
-  fail_unless(tmesh_knock(netB,knBA,NULL));
+  LOG("AB tx is %d chan %d at %lu nonce %s",knAB->tx,knAB->chan,knAB->start,util_hex(mAB->nonce,8,NULL));
+  fail_unless(knAB->tx == 1);
+  while(!tmesh_knock(netB,knBA,NULL)) fail_unless(tmesh_bttf(netB,mBA->at+1));
   fail_unless(knBA->mote == mBA);
-  LOG("tx is %d chan %d at %lu nonce %s",knBA->tx,knBA->chan,knAB->start,util_hex(mBA->nonce,8,NULL));
-  fail_unless(knBA->tx == 1);
+  LOG("BA tx is %d chan %d at %lu nonce %s",knBA->tx,knBA->chan,knAB->start,util_hex(mBA->nonce,8,NULL));
+  fail_unless(knBA->tx == 0);
   
   // dance
   memcpy(knBA->frame,knAB->frame,64);


### PR DESCRIPTION
a nice refactor to remove any fixed time references/logic inside of tmesh, all of the times are now relative in 32bit microseconds to a given/updating reference (that must be updated at least once every 70 minutes to preserve sync)