### PR TITLE
Fix telehash's strdup implementation leaking memory when passed a nul…

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -36,8 +36,8 @@ int util_ct_memcmp(const void* s1, const void* s2, size_t n);
 
 // embedded may not have strdup but it's a kinda handy shortcut
 char *util_strdup(const char *str);
-#ifndef strdup
+#ifdef DEF_STRDUP
 #define strdup util_strdup
-#endif
+#endif // DEF_STRDUP
 
 #endif

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -190,6 +190,7 @@ char *util_strdup(const char *str)
   char *ret;
   size_t len = 0;
   if(str) len = strlen(str);
+  if(!len) return NULL;
   if(!(ret = malloc(len+1))) return NULL;
   memcpy(ret,str,len);
   ret[len] = 0;


### PR DESCRIPTION
…l pointer. Also, redfine the preprocessor guard surrounding said strdup implementation so that it actually works and is a proactive choice i.e. if a client wants to use it, they must define a preprocessor var to get it